### PR TITLE
Fix a bug

### DIFF
--- a/src/Spaces/PolynomialSpace.jl
+++ b/src/Spaces/PolynomialSpace.jl
@@ -265,7 +265,7 @@ clenshaw(sp::PolynomialSpace,c::AbstractMatrix,x) = clenshaw(c,x,ClenshawPlan(pr
 clenshaw!(sp::PolynomialSpace,c::AbstractVector,x::AbstractVector)=clenshaw!(c,x,ClenshawPlan(promote_type(eltype(c),eltype(x)),sp,length(x)))
 
 function clenshaw(sp::PolynomialSpace,c::AbstractVector,x)
-    N,T = length(c),promote_type(eltype(c),typeof(x))
+    N,T = length(c),promote_type(prectype(sp),eltype(c),typeof(x))
     TT = eltype(T)
     if isempty(c)
         return zero(T)

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -6,6 +6,9 @@ import ApproxFunBase: space, SpaceOperator,
                     testfunctional
 
 @testset "Spaces" begin
+    @testset "evaluate" begin
+        @test evaluate([1],Legendre(),0)==evaluate([1.0],Legendre(),0)
+    end
     @testset "ChebyshevDirichlet" begin
         testtransforms(ChebyshevDirichlet{1,1}())
 


### PR DESCRIPTION
`evaluate([1],Legendre(),0)` 

throws
InexactError: Int64(0.5)

while
`evaluate([1.0],Legendre(),0)`

works fine